### PR TITLE
 Invoked done() in #after to prevent exit status 1.

### DIFF
--- a/test/ks_android_test.js
+++ b/test/ks_android_test.js
@@ -36,7 +36,9 @@ before('suite setup', function () {
 	});
 });
 
-after('suite teardown', function () {
+after('suite teardown', function (done) {
+	// Invoking done() prevents exit status 1.
+	done();
 	return driver.quit();
 });
 

--- a/test/ks_ios_test.js
+++ b/test/ks_ios_test.js
@@ -34,7 +34,9 @@ before('suite setup', function () {
 	});
 });
 
-after('suite teardown', function () {
+after('suite teardown', function (done) {
+	// Invoking done() prevents exit status 1.
+	done();
 	return driver.quit();
 });
 


### PR DESCRIPTION
#### Test case
In `qe-appium`, enter `npm run test-android`/`npm run test-ios` in terminal. You should **NOT** see an error when the test has finished running with an exist status 1. E.g:

```
npm ERR! Darwin 16.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "test-android-button"
npm ERR! node v4.5.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! qe-appium@1.0.0 test-android-button: `mocha test/android_button_test.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the qe-appium@1.0.0 test-android-button script 'mocha test/android_button_test.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the qe-appium package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     mocha test/android_button_test.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs qe-appium
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls qe-appium
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/fmerzadyan/.npm/_logs/2017-07-26T21_38_17_901Z-debug.log
```